### PR TITLE
Add basic api to get stolen amt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ hex = "0.4"
 sha2 = "0.10.6"
 sled = { version = "0.34", optional = true }
 redis = { version = "0.22.1", features = ["tokio-comp"], optional = true }
+axum = "0.5.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ sha2 = "0.10.6"
 sled = { version = "0.34", optional = true }
 redis = { version = "0.22.1", features = ["tokio-comp"], optional = true }
 axum = "0.5.17"
+dioxus = { version = "0.2.4", features = ["ssr"] }


### PR DESCRIPTION
adds a basic api at `/stolen` that shows the current total amt stolen in msats

also tried the sever-side rendering for the current total stolen at the index `/`